### PR TITLE
Fixed incorrect line numbers in 08-defensive.md

### DIFF
--- a/_episodes/08-defensive.md
+++ b/_episodes/08-defensive.md
@@ -131,7 +131,7 @@ def normalize_rectangle(rect):
 ~~~
 {: .python}
 
-The preconditions on lines 2, 4, and 5 catch invalid inputs:
+The preconditions on lines 3, 5, and 6 catch invalid inputs:
 
 ~~~
 print(normalize_rectangle( (0.0, 1.0, 2.0) )) # missing the fourth coordinate
@@ -177,7 +177,7 @@ AssertionError: Invalid X coordinates
 ~~~
 {: .error}
 
-The post-conditions help us catch bugs by telling us when our calculations cannot have been correct.
+The post-conditions on lines 17 and 18 help us catch bugs by telling us when our calculations cannot have been correct.
 For example,
 if we normalize a rectangle that is taller than it is wide everything seems OK:
 
@@ -217,7 +217,7 @@ AssertionError: Calculated upper Y coordinate invalid
 {: .error}
 
 Re-reading our function,
-we realize that line 10 should divide `dy` by `dx` rather than `dx` by `dy`.
+we realize that line 11 should divide `dy` by `dx` rather than `dx` by `dy`.
 (You can display line numbers by typing Ctrl-M, then L.)
 If we had left out the assertion at the end of the function,
 we would have created and returned something that had the right shape as a valid answer,


### PR DESCRIPTION
The line numbers referred to in the normalize_rectangle function of defensive programming were incorrect.  My guess is the comment line was added later, and the line numbers were not updated.  I corrected "The preconditions on lines 2, 4, and 5 catch invalid inputs:" to be "The preconditions on lines 3, 5, and 6 catch invalid inputs:" and "...we realize that line 10..." to be "...we realize that line 11..."

Also added the line numbers for the post-conditions "The post-conditions on lines 17 and 18...".  This clarifies to learners which assertions were preconditions and which ones were post-conditions